### PR TITLE
chore: update test asserts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ mod test {
 
         let config = builder.build();
 
-        assert_eq!(config.report_logs_in_timings, false);
+        assert!(!config.report_logs_in_timings);
     }
 
     #[test]
@@ -65,8 +65,8 @@ mod test {
 
         let config = builder.build();
 
-        assert_eq!(config.report_logs_in_console, false);
-        assert_eq!(config.use_console_color, false);
+        assert!(!config.report_logs_in_console);
+        assert!(!config.use_console_color);
     }
 
     #[test]
@@ -76,8 +76,8 @@ mod test {
 
         let config = builder.build();
 
-        assert_eq!(config.report_logs_in_console, true);
-        assert_eq!(config.use_console_color, false);
+        assert!(config.report_logs_in_console);
+        assert!(!config.use_console_color);
     }
 
     #[test]
@@ -87,8 +87,8 @@ mod test {
 
         let config = builder.build();
 
-        assert_eq!(config.report_logs_in_console, true);
-        assert_eq!(config.use_console_color, true);
+        assert!(config.report_logs_in_console);
+        assert!(config.use_console_color);
     }
 
     #[test]


### PR DESCRIPTION
resolves the lint warning of using assert_eq! with comparison of a boolean value