### PR TITLE
feat: wasm e2e tests + github ci

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ Given a [`WasmLayerConfig`], set WASM to be the default recorder.
 use console_error_panic_hook;
 use wasm_bindgen::prelude::*;
 use wasm_tracing::prelude::*;
+use tracing::Level;
 
 #[wasm_bindgen(start)]
 pub fn start() -> Result<(), JsValue> {

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,8 +1,27 @@
+use tracing::{event, span, Level};
 use wasm_bindgen_test::*;
+use wasm_tracing::WasmLayerConfig;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-pub fn test() {
-    wasm_tracing::set_as_global_default();
+pub fn simple_test() {
+    console_error_panic_hook::set_once();
+    let config = WasmLayerConfig::new()
+        .set_max_level(Level::DEBUG)
+        .set_show_origin(false)
+        .set_show_fields(false)
+        .to_owned();
+    wasm_tracing::set_as_global_default_with_config(config);
+
+    throw_events();
+}
+
+pub fn throw_events() {
+    event!(Level::INFO, "Foobar");
+    event!(Level::WARN, "Warn log");
+    let span = span!(Level::INFO, "Test span");
+    let _guard = span.enter();
+    event!(Level::DEBUG, "Inside span");
+    event!(Level::ERROR, "Error log");
 }


### PR DESCRIPTION
## Objective
Test browser console via github CI, add initial tests.

## Solutions
- [x] Add `wasm-bindgen-test` to dev dependencies
- [x] Tests sample tracing function for all different configurations
- [x] Add github CI to run browser tests

## Side Effects
- Updated README to point to `wasm-tracing` docs