### PR TITLE
add `origin_base_url` to `WasmLayerConfig`

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,7 @@ pub use console::*;
 pub type WASMLayerConfig = WasmLayerConfig;
 
 ///Configuration parameters for the [WasmLayer](crate::prelude::WasmLayer).
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct WasmLayerConfig {
     /// In dev-tools, report timings of traces
     pub report_logs_in_timings: bool,
@@ -18,6 +18,8 @@ pub struct WasmLayerConfig {
     pub show_fields: bool,
     /// Show origin (line number, source)
     pub show_origin: bool,
+    /// Optional URL to prepend to origins. E.g. to allow for showing full file paths that can be navigated when logged in the browser console.
+    pub origin_base_url: Option<String>,
 }
 
 impl Default for WasmLayerConfig {
@@ -28,6 +30,7 @@ impl Default for WasmLayerConfig {
             max_level: tracing::Level::TRACE,
             show_fields: true,
             show_origin: true,
+            origin_base_url: None,
         }
     }
 }
@@ -67,6 +70,12 @@ impl WasmLayerConfig {
         self
     }
 
+    /// Set the base URL for origins. This can be used to show full file paths in the browser console.
+    pub fn set_origin_base_url(&mut self, origin_base_url: impl ToString) -> &mut Self {
+        self.origin_base_url = Some(origin_base_url.to_string());
+        self
+    }
+
     /// True if the console reporting spans
     pub fn console_enabled(&self) -> bool {
         self.console.reporting_enabled()
@@ -84,7 +93,8 @@ fn test_default_built_config() {
             console: ConsoleConfig::ReportWithConsoleColor,
             max_level: tracing::Level::TRACE,
             show_fields: true,
-            show_origin: true
+            show_origin: true,
+            origin_base_url: None
         }
     )
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -127,7 +127,16 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WasmLayer {
         }
         let origin = if self.config.show_origin {
             meta.file()
-                .and_then(|file| meta.line().map(|ln| format!("{}:{}", file, ln)))
+                .and_then(|file| {
+                    meta.line().map(|ln| {
+                        format!(
+                            "{}{}:{}",
+                            self.config.origin_base_url.as_deref().unwrap_or_default(),
+                            file,
+                            ln
+                        )
+                    })
+                })
                 .unwrap_or_default()
         } else {
             String::new()


### PR DESCRIPTION
This can be a url that gets prependend to origins (file locations). When printed into a browser console with debug symbols enabled (e.g. via https://github.com/rustwasm/wasm-bindgen/issues/2389), it becomes possible to navigate to sources.

A configuration through an env var in a debug environmen could look like

```rust
    #[cfg(debug_assertions)]
    {
        if let Some(origin_base_url) = option_env!("WASM_TRACING_BASE_URL") {
            config.set_origin_base_url(origin_base_url);
        }
    }
```

https://github.com/user-attachments/assets/ee8ae5ce-f703-4261-83b3-2507b0cbdc57



---

This is a breaking change as it requires `WasmLayerConfig` to not be `Copy`.