### PR TITLE
fix: remove crate-type in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/dsgallups/wasm-tracing"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dependencies]
 rayon = { version = "1.10", optional = true }
 tracing = { version = "0.1", features = [


### PR DESCRIPTION
From issue in https://github.com/old-storyai/tracing-wasm/issues/31

This value in a wasm dependency is unnecessary.

I could be wrong, but I doubt this is a breaking change, but I think this satisfies the need for a minor bump.